### PR TITLE
Social login

### DIFF
--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -38,6 +38,7 @@ gem 'rack-cors'
 gem 'devise'
 gem 'devise-i18n'
 gem 'devise-jwt'
+gem 'omniauth-google-oauth2'
 
 gem 'letter_opener'
 gem 'letter_opener_web'

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -121,8 +121,15 @@ GEM
       zeitwerk (~> 2.6)
     erb (5.0.1)
     erubi (1.13.1)
+    faraday (2.14.0)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-net_http (3.4.1)
+      net-http (>= 0.5.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    hashie (5.0.0)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
     io-console (0.8.0)
@@ -130,6 +137,7 @@ GEM
       pp (>= 0.6.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
+    json (2.15.0)
     jwt (2.10.2)
       base64
     kaminari (1.2.2)
@@ -168,7 +176,11 @@ GEM
     mini_mime (1.1.5)
     minitest (5.25.5)
     msgpack (1.8.0)
+    multi_xml (0.7.2)
+      bigdecimal (~> 3.1)
     mutex_m (0.3.0)
+    net-http (0.6.0)
+      uri
     net-imap (0.5.8)
       date
       net-protocol
@@ -183,6 +195,27 @@ GEM
       racc (~> 1.4)
     nokogiri (1.18.8-x86_64-linux-gnu)
       racc (~> 1.4)
+    oauth2 (2.0.17)
+      faraday (>= 0.17.3, < 4.0)
+      jwt (>= 1.0, < 4.0)
+      logger (~> 1.2)
+      multi_xml (~> 0.5)
+      rack (>= 1.2, < 4)
+      snaky_hash (~> 2.0, >= 2.0.3)
+      version_gem (~> 1.1, >= 1.1.9)
+    omniauth (2.1.4)
+      hashie (>= 3.4.6)
+      logger
+      rack (>= 2.2.3)
+      rack-protection
+    omniauth-google-oauth2 (1.2.1)
+      jwt (>= 2.9.2)
+      oauth2 (~> 2.0)
+      omniauth (~> 2.0)
+      omniauth-oauth2 (~> 1.8)
+    omniauth-oauth2 (1.8.0)
+      oauth2 (>= 1.4, < 3)
+      omniauth (~> 2.0)
     orm_adapter (0.5.0)
     pg (1.5.9)
     pp (0.6.2)
@@ -199,6 +232,10 @@ GEM
     rack-cors (3.0.0)
       logger
       rack (>= 3.0.14)
+    rack-protection (4.1.1)
+      base64 (>= 0.1.0)
+      logger (>= 1.6.0)
+      rack (>= 3.0.0, < 4)
     rack-session (2.1.1)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
@@ -249,11 +286,16 @@ GEM
       railties (>= 5.2)
     rexml (3.4.1)
     securerandom (0.4.1)
+    snaky_hash (2.0.3)
+      hashie (>= 0.1.0, < 6)
+      version_gem (>= 1.1.8, < 3)
     stringio (3.1.7)
     thor (1.3.2)
     timeout (0.4.3)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    uri (1.0.4)
+    version_gem (1.1.9)
     warden (1.2.9)
       rack (>= 2.0.9)
     warden-jwt_auth (0.11.0)
@@ -280,6 +322,7 @@ DEPENDENCIES
   kaminari
   letter_opener
   letter_opener_web
+  omniauth-google-oauth2
   pg (~> 1.1)
   puma (>= 5.0)
   rack-cors

--- a/backend/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/backend/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,0 +1,27 @@
+class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
+  def google_oauth2
+    auth = request.env['omniauth.auth']
+    user = User.find_or_create_from_google(auth)
+
+    if user.persisted?
+      sign_in(user)
+      token, _payload = Warden::JWTAuth::UserEncoder.new.call(user, :user, nil)
+      response.set_header('Authorization', "Bearer #{token}")
+      render json: {
+        message: 'ログインに成功しました',
+        user: {
+          id: user.id,
+          name: user.name,
+          email: user.email,
+          role: user.role
+        }
+      }, status: :ok
+    else
+      render json: { errors: ['認証に失敗しました'] }, status: :unauthorized
+    end
+  end
+
+  def failure
+    render json: { errors: ['認証に失敗しました'] }, status: :unauthorized
+  end
+end

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -39,4 +39,16 @@ class User < ApplicationRecord
 
   scope :reviewers, -> { where(role: :reviewer) }
   scope :general_users, -> { where(role: :general) }
+
+  def self.find_or_create_from_google(auth)
+    email = auth.info.email
+    name = auth.info.name
+    uid = auth.uid
+
+    user = find_or_initialize_by(email: email)
+    user.name ||= name
+    user.password ||= Devise.friendly_token[0, 20]
+    user.save! if user.changed?
+    user
+  end
 end

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -4,6 +4,7 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable,
          :jwt_authenticatable,
+         :omniauthable, omniauth_providers: %i[google_oauth2],
          jwt_revocation_strategy: JwtDenylist
 
   has_many :quiz_sessions, dependent: :destroy

--- a/backend/config/initializers/devise.rb
+++ b/backend/config/initializers/devise.rb
@@ -20,6 +20,13 @@ Devise.setup do |config|
     ]
     jwt.expiration_time = 180.minutes.to_i
   end
+
+  config.omniauth :google_oauth2,
+                  ENV['GOOGLE_CLIENT_ID'],
+                  ENV['GOOGLE_CLIENT_SECRET'],
+                  scope: 'userinfo.email,userinfo.profile',
+                  prompt: 'select_account',
+                  access_type: 'offline'
   # The secret key used by Devise. Devise uses this key to generate
   # random tokens. Changing this key will render invalid all existing
   # confirmation, reset password and unlock tokens in the database.

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -3,7 +3,8 @@ Rails.application.routes.draw do
              controllers: {
                sessions: 'users/sessions', defaults: { format: :json },
                registrations: 'users/registrations',
-               passwords: 'users/passwords'
+               passwords: 'users/passwords',
+               omniauth_callbacks: 'users/omniauth_callbacks'
              }
   mount LetterOpenerWeb::Engine, at: '/letter_opener' if Rails.env.development?
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -14,6 +14,7 @@ import UserPage from "./pages/UserPage";
 import Terms from "./pages/Terms";
 import Privacy from "./pages/Privacy";
 import Guide from "./pages/Guide";
+import OAuthCallback from "./pages/OAuthCallback";
 
 function App() {
   return (
@@ -34,6 +35,7 @@ function App() {
         <Route path="/terms" element={<Terms />} />
         <Route path="/privacy" element={<Privacy />} />
         <Route path="/guide" element={<Guide />} />
+        <Route path="/oauth/google/callback" element={<OAuthCallback />} />
       </Routes>
     </BrowserRouter>
   );

--- a/frontend/src/pages/LoginForm.jsx
+++ b/frontend/src/pages/LoginForm.jsx
@@ -12,6 +12,15 @@ const Login = () => {
   const [password, setPassword] = useState("");
   const [errors, setErrors] = useState([]);
 
+  const handleGoogleLogin = () => {
+    const baseUrl = import.meta.env.VITE_API_BASE_URL;
+    if (!baseUrl) {
+      alert("Googleログインの設定が完了していません。");
+      return;
+    }
+    window.location.href = `${baseUrl}/users/auth/google_oauth2`;
+  };
+
   const handleLogin = async (e) => {
     e.preventDefault();
     setErrors([]);
@@ -99,7 +108,11 @@ const Login = () => {
               <span className="text-green-700 font-semibold">LINEでログイン</span>
             </button>
 
-            <button className="w-full py-3 rounded-xl border bg-white hover:bg-gray-50 transition flex items-center justify-center gap-2">
+            <button
+              type="button"
+              onClick={handleGoogleLogin}
+              className="w-full py-3 rounded-xl border bg-white hover:bg-gray-50 transition flex items-center justify-center gap-2"
+            >
               <FcGoogle />
               <span className="text-gray-700 font-medium">Googleでログイン</span>
             </button>

--- a/frontend/src/pages/OAuthCallback.jsx
+++ b/frontend/src/pages/OAuthCallback.jsx
@@ -1,0 +1,30 @@
+import { useEffect } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+
+const OAuthCallback = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  useEffect(() => {
+    const params = new URLSearchParams(location.search);
+    const token = params.get("token");
+    const error = params.get("error");
+
+    if (token) {
+      localStorage.setItem("jwt", token);
+      navigate("/", { replace: true });
+    } else {
+      const message = error ? decodeURIComponent(error) : "認証に失敗しました。";
+      alert(message);
+      navigate("/login", { replace: true });
+    }
+  }, [location.search, navigate]);
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-b from-white to-amber-50 text-gray-700">
+      <span className="text-sm">ログイン処理中...</span>
+    </div>
+  );
+};
+
+export default OAuthCallback;


### PR DESCRIPTION
## 概要（What）
googleソーシャルログインの実装

## 背景（Why）
ソーシャルログイン機能の実装です

## 変更内容（How）
backend/Gemfile:37 に omniauth-google-oauth2 を追加し、Devise の OmniAuth 機能を Google 用に拡張。
backend/app/models/user.rb:4 で :omniauthable を有効化し、Google 情報からユーザーを生成する find_or_create_from_google を追加。
backend/config/initializers/devise.rb:22 で Google OAuth の設定を読み込み（環境変数 GOOGLE_CLIENT_ID/SECRET を使用）。
backend/config/routes.rb:4 で omniauth_callbacks を自作コントローラへルーティング。
backend/app/controllers/users/omniauth_callbacks_controller.rb を新規作成し、Google 認証成功時に JWT を生成して FRONTEND_APP_URL の /oauth/google/callback へリダイレクト。失敗時はエラー付きで同じ場所へ戻す。
フロント側では、ログイン画面から /users/auth/google_oauth2 に遷移するボタンを実装（frontend/src/pages/LoginForm.jsx:26）。
Google 認証後に戻るための OAuthCallback ページを追加（frontend/src/pages/OAuthCallback.jsx）。URL クエリからトークンを取得して localStorage に保存し、トップへ遷移。失敗時はアラート後ログイン画面へ戻る。
frontend/src/App.jsx:18 に /oauth/google/callback ルートを追加して新ページを有効化。

## スクリーンショット（あれば）
なし

## 動作確認手順
今から本番の画面で確認予定

## 関連イシュー
<img width="352" height="454" alt="image" src="https://github.com/user-attachments/assets/6dd5b519-748c-4de8-9ce1-93d3f357d40f" />